### PR TITLE
RM redundant isTestable

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/access/model/Task.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/model/Task.kt
@@ -114,9 +114,6 @@ class Task {
         return formCommand(type) != null
     }
 
-    val isTestable: Boolean
-        get() = hasCommand(Command.TEST)
-
     @PrePersist
     @PreUpdate
     fun validateAssignmentOrCourseReference() {

--- a/src/main/kotlin/ch/uzh/ifi/access/projections/TaskWorkspace.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/projections/TaskWorkspace.kt
@@ -9,7 +9,6 @@ import java.time.LocalDateTime
 
 @Projection(types = [Task::class])
 interface TaskWorkspace : TaskOverview {
-    val isTestable: Boolean
 
     @get:Value("#{@courseService.getTaskFiles(target.id)}")
     val files: List<TaskFile?>?


### PR DESCRIPTION
As we now only rely on `task.testCommandAvailable` in the frontend

(See https://github.com/mp-access/Frontend-Re/pull/81)