### PR TITLE
More granular emitters & open in editor endpoint

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
@@ -6,6 +6,7 @@ import ch.uzh.ifi.access.model.dto.ExampleInformationDTO
 import ch.uzh.ifi.access.model.dto.SubmissionDTO
 import ch.uzh.ifi.access.projections.TaskWorkspace
 import ch.uzh.ifi.access.service.EmitterService
+import ch.uzh.ifi.access.service.EmitterType
 import ch.uzh.ifi.access.service.ExampleService
 import ch.uzh.ifi.access.service.RoleService
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -15,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
+import java.util.*
 
 
 @RestController
@@ -101,8 +103,13 @@ class ExampleController(
 
         val updatedExample = exampleService.publishExampleBySlug(course, example, body.duration)
 
-        emitterService.sendMessage(course, "redirect", "/courses/$course/examples/$example")
-        emitterService.sendMessage(course, "timer-update", "${updatedExample.start}/${updatedExample.end}")
+        emitterService.sendPayload(EmitterType.STUDENT, course, "redirect", "/courses/$course/examples/$example")
+        emitterService.sendPayload(
+            EmitterType.EVERYONE,
+            course,
+            "timer-update",
+            "${updatedExample.start}/${updatedExample.end}"
+        )
     }
 
     // Invoked by the teacher when want to extend the time of an active example by a certain amount of seconds
@@ -115,12 +122,18 @@ class ExampleController(
     ) {
         val updatedExample = exampleService.extendExampleDeadlineBySlug(course, example, body.duration)
 
-        emitterService.sendMessage(
+        emitterService.sendPayload(
+            EmitterType.EVERYONE,
             course,
             "message",
             "Submission time extended by the lecturer by ${body.duration} seconds."
         )
-        emitterService.sendMessage(course, "timer-update", "${updatedExample.start}/${updatedExample.end}")
+        emitterService.sendPayload(
+            EmitterType.EVERYONE,
+            course,
+            "timer-update",
+            "${updatedExample.start}/${updatedExample.end}"
+        )
     }
 
     // Invoked by the teacher when want to terminate the active example
@@ -131,11 +144,19 @@ class ExampleController(
         @PathVariable example: String
     ) {
         val updatedExample = exampleService.terminateExampleBySlug(course, example)
-        emitterService.sendMessage(
+        emitterService.sendPayload(
+            EmitterType.EVERYONE,
             course,
             "message",
             "The example has been terminated by the lecturer."
         )
-        emitterService.sendMessage(course, "timer-update", "${updatedExample.start}/${updatedExample.end}")
+        emitterService.sendPayload(
+            EmitterType.EVERYONE,
+            course,
+            "timer-update",
+            "${updatedExample.start}/${updatedExample.end}"
+        )
+    }
+
     }
 }

--- a/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
@@ -158,5 +158,22 @@ class ExampleController(
         )
     }
 
+    // Invoked by the teacher when publishing an example to inform the students
+    @PostMapping("/{example}/user/{userId}/inspect")
+    @PreAuthorize("hasRole(#course+'-supervisor')")
+    fun getSubmissionInspectionPath(
+        @PathVariable course: String,
+        @PathVariable example: String,
+        @PathVariable userId: String,
+    ) {
+
+        val encodedUserId = Base64.getEncoder().encodeToString(userId.toByteArray())
+        emitterService.sendPayload(
+            EmitterType.SUPERVISOR,
+            course,
+            "inspect",
+            "/courses/$course/examples/$example/public-dashboard/inspect/users/$encodedUserId"
+
+        )
     }
 }

--- a/src/main/kotlin/ch/uzh/ifi/access/service/EmitterType.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/service/EmitterType.kt
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.access.service
+
+enum class EmitterType {
+    SUPERVISOR,
+    EVERYONE,
+    STUDENT
+}

--- a/src/main/kotlin/ch/uzh/ifi/access/service/RoleService.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/service/RoleService.kt
@@ -317,6 +317,15 @@ class RoleService(
         return registrationID
     }
 
+    fun isSupervisor(courseSlug: String): Boolean {
+        val registrationID = getCurrentUsername()
+        val user = proxy.findUserByAllCriteria(registrationID)
+            ?: throw Exception("User with registrationID $registrationID not found")
+
+        val roles = user.toResource().roles().realmLevel().listEffective()
+        return roles.any { it.name == "${courseSlug}-supervisor" }
+    }
+
     @Cacheable("RoleService.getOnlineCount", key = "#courseSlug")
     fun getOnlineCount(courseSlug: String): Int {
         val clientRepresentation = accessRealm.clients().findByClientId("access-client")[0]


### PR DESCRIPTION
- We now register student and supervisor emitters and can send out SSEs to either one those groups or both. This makes sure some rather sensitive information as e.g., student submissions get only sent to supervisors. 
- An endpoint returning an URL to inspect a specific student submission has been created. The student id (email) gets encoded into Base64, such that student email are not directly visible in the URL when the lecturer inspects a submission.

close #71 