### PR TITLE
ExampleSubmissionsDTO avg point addition

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/controller/ExampleController.kt
@@ -75,6 +75,7 @@ class ExampleController(
         val submissions = exampleService.getInteractiveExampleSubmissions(course, example)
         val numberOfStudentsWhoSubmitted = submissions.size
         val passRatePerTestCase = exampleService.getExamplePassRatePerTestCase(course, example, submissions)
+        val avgPoints = exampleService.calculateAvgPoints(submissions)
 
         val submissionsDTO = submissions.map {
             SubmissionSseDTO(
@@ -94,6 +95,7 @@ class ExampleController(
             totalParticipants,
             numberOfStudentsWhoSubmitted,
             passRatePerTestCase,
+            avgPoints,
             submissionsDTO
         )
     }

--- a/src/main/kotlin/ch/uzh/ifi/access/model/dto/ExampleSubmissionsDTO.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/model/dto/ExampleSubmissionsDTO.kt
@@ -5,5 +5,6 @@ class ExampleSubmissionsDTO(
     val totalParticipants: Long,
     val numberOfStudentsWhoSubmitted: Int,
     val passRatePerTestCase: Map<String, Double>,
+    val avgPoints: Double,
     val submissions: List<SubmissionSseDTO>,
 )


### PR DESCRIPTION
Currently, only SSE was sending `avgPoints`. When refetching the example information, we also need this information. 