### PR TITLE
Converted task workspace to task overview in list of examples endpoint

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/access/projections/CourseWorkspace.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/projections/CourseWorkspace.kt
@@ -10,5 +10,5 @@ interface CourseWorkspace : CourseOverview {
     val assignments: List<AssignmentWorkspace?>?
 
     @get:Value("#{@exampleService.getExamples(target.slug)}")
-    val examples: List<TaskWorkspace?>?
+    val examples: List<TaskOverview?>?
 }

--- a/src/main/kotlin/ch/uzh/ifi/access/repository/ExampleRepository.kt
+++ b/src/main/kotlin/ch/uzh/ifi/access/repository/ExampleRepository.kt
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.access.repository
 
 import ch.uzh.ifi.access.model.Task
+import ch.uzh.ifi.access.projections.TaskOverview
 import ch.uzh.ifi.access.projections.TaskWorkspace
 import org.springframework.data.jpa.repository.JpaRepository
 
@@ -8,7 +9,7 @@ interface ExampleRepository : JpaRepository<Task?, Long?> {
 
     fun findByCourse_SlugOrderByOrdinalNumDesc(
         courseSlug: String?
-    ): List<TaskWorkspace>
+    ): List<TaskOverview>
 
     fun findByCourse_SlugAndSlug(
         courseSlug: String?,


### PR DESCRIPTION
Converted task workspace to task overview for less information to be sent to the frontend.
Frontend is fine and working. Some changes are automatically applied because of the IntelliJ formatter.
close #189 